### PR TITLE
feat: add --nessus flag to seed DB from .nessus export files (#8)

### DIFF
--- a/hacksmarter.py
+++ b/hacksmarter.py
@@ -25,6 +25,7 @@ from agents import recon_node, strategy_node, vuln_node
 from state import PentestState
 import tools
 from tools import set_allowed_scope
+from nessus_parser import parse_nessus_file, seed_db_from_nessus
 
 # ---------------------------------------------------------------------------
 # Logging setup (called from __main__ after args are parsed)
@@ -134,6 +135,7 @@ def run_swarm(
     excluded_tools: list,
     client_name: str = None,
     verbose: bool = False,
+    nessus_file: str = None,
 ):
     """Run the AI swarm against the provided target list."""
     if excluded_tools:
@@ -149,6 +151,38 @@ def run_swarm(
 
     # FIX: register the authorised scope BEFORE any tool is invoked
     set_allowed_scope(targets)
+
+    # ------------------------------------------------------------------
+    # Optional: seed the database from a .nessus file before scanning
+    # ------------------------------------------------------------------
+    if nessus_file:
+        logger.info("Loading Nessus baseline from: %s", nessus_file)
+        try:
+            nessus_result = parse_nessus_file(nessus_file)
+            summary = seed_db_from_nessus(nessus_result)
+            logger.info(
+                "Nessus import complete — %d host(s), %d port(s), "
+                "%d vuln(s) seeded into DB.",
+                summary["hosts"],
+                summary["open_ports"],
+                summary["vulnerabilities"],
+            )
+            # Extend scope to include any hosts discovered in the Nessus file
+            # that aren't already in the target list (e.g. extra IPs/FQDNs).
+            nessus_targets = [
+                t for t in nessus_result.targets if t not in targets
+            ]
+            if nessus_targets:
+                logger.info(
+                    "Extending scope with %d host(s) from Nessus file: %s",
+                    len(nessus_targets),
+                    nessus_targets,
+                )
+                targets = targets + nessus_targets
+                set_allowed_scope(targets)
+        except (FileNotFoundError, ValueError) as exc:
+            logger.error("Failed to load Nessus file: %s", exc)
+            raise SystemExit(1) from exc
 
     for index, target in enumerate(targets):
         logger.info("=" * 40)
@@ -222,6 +256,17 @@ if __name__ == "__main__":
         "-c", "--client",
         help="Client name — organises all output under clients/<name>/.",
     )
+    parser.add_argument(
+        "-n", "--nessus",
+        metavar="FILE",
+        help=(
+            "Path to a .nessus export file. Findings are seeded into the DB "
+            "as a baseline before the AI swarm runs, so the swarm focuses on "
+            "verifying and deepening existing findings rather than starting "
+            "from scratch. Hosts discovered in the file are added to scope "
+            "automatically."
+        ),
+    )
     args = parser.parse_args()
 
     _configure_logging(args.verbose)
@@ -232,4 +277,4 @@ if __name__ == "__main__":
     logger.info("Initialising Hack Smarter Swarm…")
     logger.info("Loaded %d target(s).", len(targets))
 
-    run_swarm(targets, excluded, args.client, args.verbose)
+    run_swarm(targets, excluded, args.client, args.verbose, args.nessus)

--- a/nessus_parser.py
+++ b/nessus_parser.py
@@ -1,0 +1,270 @@
+"""
+nessus_parser.py — Parse Nessus XML (.nessus) export files and seed
+                   the HackSmarter SQLite database with the findings.
+
+A .nessus file is a Nessus XML v2 document with this rough shape:
+
+  <NessusClientData_v2>
+    <Report name="...">
+      <ReportHost name="192.168.1.1">
+        <HostProperties>
+          <tag name="host-fqdn">example.com</tag>
+          ...
+        </HostProperties>
+        <ReportItem port="443" protocol="tcp" severity="3"
+                    pluginName="SSL Certificate Expiry"
+                    pluginID="15901" ...>
+          <description>...</description>
+          <solution>...</solution>
+          <plugin_output>...</plugin_output>
+        </ReportItem>
+        ...
+      </ReportHost>
+    </Report>
+  </NessusClientData_v2>
+
+Severity mapping (Nessus integer → human label):
+  0 → info   1 → low   2 → medium   3 → high   4 → critical
+
+Only items with severity >= 1 are imported as vulnerabilities.
+Informational items (severity 0) with an open port are still used
+to seed the open_ports table.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+try:
+    import defusedxml.ElementTree as ET
+except ImportError:  # pragma: no cover – defusedxml is in requirements
+    import xml.etree.ElementTree as ET  # type: ignore
+
+logger = logging.getLogger("hacksmarter.nessus_parser")
+
+# ---------------------------------------------------------------------------
+# Severity helpers
+# ---------------------------------------------------------------------------
+
+_SEVERITY_MAP = {0: "info", 1: "low", 2: "medium", 3: "high", 4: "critical"}
+
+
+def _severity_label(raw: int) -> str:
+    return _SEVERITY_MAP.get(raw, "info")
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NessusHost:
+    ip: str
+    fqdn: Optional[str] = None
+    os_name: Optional[str] = None
+
+
+@dataclass
+class NessusFinding:
+    host: str          # IP or FQDN used as the "target"
+    port: str
+    protocol: str
+    plugin_id: str
+    plugin_name: str
+    severity: int      # 0-4 integer
+    description: str
+    solution: str
+    plugin_output: str
+
+
+@dataclass
+class NessusParseResult:
+    hosts: List[NessusHost] = field(default_factory=list)
+    findings: List[NessusFinding] = field(default_factory=list)
+    targets: List[str] = field(default_factory=list)  # unique host identifiers
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+def parse_nessus_file(path: str) -> NessusParseResult:
+    """
+    Parse a .nessus XML file and return a :class:`NessusParseResult`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist.
+    ValueError
+        If the file does not look like a Nessus XML v2 document.
+    """
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Nessus file not found: {path}")
+
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:
+        raise ValueError(f"Failed to parse XML in {path}: {exc}") from exc
+
+    root = tree.getroot()
+    if "NessusClientData" not in root.tag:
+        raise ValueError(
+            f"Not a Nessus XML v2 file (root tag: <{root.tag}>). "
+            "Export as '.nessus' from Nessus / Tenable.io."
+        )
+
+    result = NessusParseResult()
+    seen_targets: set = set()
+
+    for report in root.findall(".//Report"):
+        for report_host in report.findall("ReportHost"):
+            ip = report_host.get("name", "").strip()
+            if not ip:
+                continue
+
+            # ---- Host metadata ----------------------------------------
+            props = report_host.find("HostProperties")
+            fqdn: Optional[str] = None
+            os_name: Optional[str] = None
+            if props is not None:
+                for tag in props.findall("tag"):
+                    name = tag.get("name", "")
+                    val = (tag.text or "").strip()
+                    if name == "host-fqdn" and val:
+                        fqdn = val
+                    elif name in ("operating-system", "os") and val:
+                        os_name = val
+
+            host_obj = NessusHost(ip=ip, fqdn=fqdn, os_name=os_name)
+            result.hosts.append(host_obj)
+
+            # Prefer FQDN as the canonical target; fall back to IP
+            canonical = fqdn or ip
+            if canonical not in seen_targets:
+                seen_targets.add(canonical)
+                result.targets.append(canonical)
+
+            # ---- ReportItems (findings) --------------------------------
+            for item in report_host.findall("ReportItem"):
+                raw_sev = int(item.get("severity", "0"))
+                port = item.get("port", "0")
+                protocol = item.get("protocol", "tcp")
+                plugin_id = item.get("pluginID", "")
+                plugin_name = item.get("pluginName", "")
+
+                description = _text(item, "description")
+                solution = _text(item, "solution")
+                plugin_output = _text(item, "plugin_output")
+
+                finding = NessusFinding(
+                    host=canonical,
+                    port=port,
+                    protocol=protocol,
+                    plugin_id=plugin_id,
+                    plugin_name=plugin_name,
+                    severity=raw_sev,
+                    description=description,
+                    solution=solution,
+                    plugin_output=plugin_output,
+                )
+                result.findings.append(finding)
+
+    logger.info(
+        "Parsed %s: %d hosts, %d findings",
+        os.path.basename(path),
+        len(result.hosts),
+        len(result.findings),
+    )
+    return result
+
+
+def _text(element, tag: str) -> str:
+    """Return stripped text of a child element, or empty string."""
+    child = element.find(tag)
+    if child is not None and child.text:
+        return child.text.strip()
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# DB seeding
+# ---------------------------------------------------------------------------
+
+def seed_db_from_nessus(result: NessusParseResult) -> dict:
+    """
+    Write parsed Nessus findings into the HackSmarter SQLite database.
+
+    Must be called **after** ``tools.init_db()`` (or ``tools.set_output_dir()``)
+    so that ``tools.DB_PATH`` is set correctly.
+
+    Returns a summary dict with counts for logging/testing.
+    """
+    import tools  # imported here to avoid circular imports at module level
+
+    subdomains: List[str] = []
+    open_ports: List[dict] = []
+    vulnerabilities: List[dict] = []
+
+    seen_ports: set = set()
+
+    for finding in result.findings:
+        port = finding.port
+        host = finding.host
+
+        # Accumulate open ports (deduplicated)
+        if port not in ("0",) and (host, port) not in seen_ports:
+            seen_ports.add((host, port))
+            open_ports.append({"target": host, "port": port})
+
+        # Severity 0 = informational — skip as a vuln, but keep port data
+        if finding.severity == 0:
+            continue
+
+        sev_label = _severity_label(finding.severity)
+        poc_parts = []
+        if finding.plugin_output:
+            poc_parts.append(f"Plugin output:\n{finding.plugin_output}")
+        if finding.solution:
+            poc_parts.append(f"Solution:\n{finding.solution}")
+        poc = "\n\n".join(poc_parts) or "See Nessus report for details."
+
+        description = finding.description or finding.plugin_name
+
+        vulnerabilities.append({
+            "target": host,
+            "template": f"nessus-{finding.plugin_id}",
+            "severity": sev_label,
+            "description": f"[Nessus] {finding.plugin_name}: {description}",
+            "poc": poc,
+        })
+
+    # Subdomains: any FQDN that differs from the bare IP
+    for h in result.hosts:
+        if h.fqdn and h.fqdn != h.ip:
+            subdomains.append(h.fqdn)
+
+    # Write to DB
+    if subdomains:
+        tools.update_db("subdomains", subdomains)
+    if open_ports:
+        tools.update_db("open_ports", open_ports)
+    if vulnerabilities:
+        tools.update_db("vulnerabilities", vulnerabilities)
+
+    # Mark nessus as having "run" for every host so the recon agent
+    # skips redundant port scans on pre-scanned targets if desired.
+    for target in result.targets:
+        tools.mark_as_run("nessus_import", target)
+
+    summary = {
+        "hosts": len(result.hosts),
+        "subdomains": len(subdomains),
+        "open_ports": len(open_ports),
+        "vulnerabilities": len(vulnerabilities),
+    }
+    logger.info("Nessus DB seed complete: %s", summary)
+    return summary

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ python-dotenv>=1.0.0
 # Pentesting Tools
 ssh-audit
 tqdm>=4.66.0
+defusedxml>=0.7.1

--- a/tests/test_nessus_parser.py
+++ b/tests/test_nessus_parser.py
@@ -1,0 +1,436 @@
+"""
+tests/test_nessus_parser.py — Unit and integration tests for the
+.nessus import feature (Feature #8).
+
+Run with:
+    pytest tests/test_nessus_parser.py -v
+"""
+
+import os
+import sqlite3
+import sys
+import tempfile
+
+import pytest
+
+# Make sure the project root is importable regardless of where pytest is invoked
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from nessus_parser import (
+    NessusFinding,
+    NessusHost,
+    NessusParseResult,
+    _severity_label,
+    parse_nessus_file,
+    seed_db_from_nessus,
+)
+import tools
+
+
+# ---------------------------------------------------------------------------
+# Helpers — tiny in-memory .nessus XML fixtures
+# ---------------------------------------------------------------------------
+
+def _write_nessus(tmp_path, xml_body: str) -> str:
+    """Write a .nessus file to a temp directory and return its path."""
+    p = os.path.join(str(tmp_path), "scan.nessus")
+    with open(p, "w") as f:
+        f.write(xml_body)
+    return p
+
+
+MINIMAL_NESSUS = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<NessusClientData_v2>\n'
+    '  <Report name="TestScan">\n'
+    '    <ReportHost name="10.0.0.1">\n'
+    '      <HostProperties>\n'
+    '        <tag name="host-fqdn">target.example.com</tag>\n'
+    '        <tag name="operating-system">Linux</tag>\n'
+    '      </HostProperties>\n'
+    '      <ReportItem port="443" protocol="tcp" severity="3"'
+    ' pluginID="15901" pluginName="SSL Certificate Expiry">\n'
+    '        <description>The SSL cert is expired.</description>\n'
+    '        <solution>Renew the certificate.</solution>\n'
+    '        <plugin_output>Serial: 1234\nExpiry: 2020-01-01</plugin_output>\n'
+    '      </ReportItem>\n'
+    '      <ReportItem port="80" protocol="tcp" severity="0"'
+    ' pluginID="11219" pluginName="Nessus SYN scanner">\n'
+    '        <description>Port 80 is open.</description>\n'
+    '      </ReportItem>\n'
+    '    </ReportHost>\n'
+    '  </Report>\n'
+    '</NessusClientData_v2>\n'
+)
+
+MULTI_HOST_NESSUS = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<NessusClientData_v2>\n'
+    '  <Report name="MultiScan">\n'
+    '    <ReportHost name="192.168.1.10">\n'
+    '      <HostProperties>\n'
+    '        <tag name="host-fqdn">web.corp.local</tag>\n'
+    '      </HostProperties>\n'
+    '      <ReportItem port="8080" protocol="tcp" severity="2"'
+    ' pluginID="99001" pluginName="Apache Outdated Version">\n'
+    '        <description>Apache 2.2 is end-of-life.</description>\n'
+    '        <solution>Upgrade to 2.4+.</solution>\n'
+    '        <plugin_output>Server: Apache/2.2.34</plugin_output>\n'
+    '      </ReportItem>\n'
+    '    </ReportHost>\n'
+    '    <ReportHost name="192.168.1.20">\n'
+    '      <HostProperties/>\n'
+    '      <ReportItem port="22" protocol="tcp" severity="1"'
+    ' pluginID="70657" pluginName="SSH Weak MAC Algorithms">\n'
+    '        <description>Weak MACs negotiated.</description>\n'
+    '        <solution>Disable weak MACs in sshd_config.</solution>\n'
+    '      </ReportItem>\n'
+    '      <ReportItem port="22" protocol="tcp" severity="4"'
+    ' pluginID="10881" pluginName="SSH Protocol Version 1 Enabled">\n'
+    '        <description>SSHv1 is insecure.</description>\n'
+    '        <solution>Disable SSHv1.</solution>\n'
+    '        <plugin_output>The remote SSH server supports SSHv1.</plugin_output>\n'
+    '      </ReportItem>\n'
+    '    </ReportHost>\n'
+    '  </Report>\n'
+    '</NessusClientData_v2>\n'
+)
+
+NO_FINDINGS_NESSUS = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<NessusClientData_v2>\n'
+    '  <Report name="Clean">\n'
+    '    <ReportHost name="10.0.0.99">\n'
+    '      <HostProperties/>\n'
+    '    </ReportHost>\n'
+    '  </Report>\n'
+    '</NessusClientData_v2>\n'
+)
+
+
+# ---------------------------------------------------------------------------
+# Severity label tests
+# ---------------------------------------------------------------------------
+
+class TestSeverityLabel:
+    def test_known_levels(self):
+        assert _severity_label(0) == "info"
+        assert _severity_label(1) == "low"
+        assert _severity_label(2) == "medium"
+        assert _severity_label(3) == "high"
+        assert _severity_label(4) == "critical"
+
+    def test_unknown_defaults_to_info(self):
+        assert _severity_label(99) == "info"
+        assert _severity_label(-1) == "info"
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+class TestParseNessusFile:
+    def test_file_not_found_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            parse_nessus_file(str(tmp_path / "nonexistent.nessus"))
+
+    def test_invalid_xml_raises(self, tmp_path):
+        bad = _write_nessus(tmp_path, "not xml at all <<<")
+        with pytest.raises(ValueError, match="Failed to parse XML"):
+            parse_nessus_file(bad)
+
+    def test_wrong_root_tag_raises(self, tmp_path):
+        bad = _write_nessus(tmp_path, "<SomeOtherFormat/>")
+        with pytest.raises(ValueError, match="Not a Nessus XML"):
+            parse_nessus_file(bad)
+
+    def test_minimal_parse_returns_correct_host_count(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        assert len(result.hosts) == 1
+
+    def test_minimal_parse_fqdn_extracted(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        assert result.hosts[0].fqdn == "target.example.com"
+
+    def test_minimal_parse_os_extracted(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        assert result.hosts[0].os_name == "Linux"
+
+    def test_minimal_parse_canonical_target_is_fqdn(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        # FQDN takes priority over IP
+        assert "target.example.com" in result.targets
+        assert len(result.targets) == 1
+
+    def test_minimal_parse_finding_count(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        # Both ReportItems (severity 3 + severity 0)
+        assert len(result.findings) == 2
+
+    def test_minimal_parse_high_severity_finding(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        high = [f for f in result.findings if f.severity == 3]
+        assert len(high) == 1
+        assert high[0].plugin_name == "SSL Certificate Expiry"
+        assert high[0].port == "443"
+        assert high[0].protocol == "tcp"
+        assert high[0].host == "target.example.com"
+
+    def test_minimal_parse_informational_finding(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        info = [f for f in result.findings if f.severity == 0]
+        assert len(info) == 1
+        assert info[0].port == "80"
+
+    def test_multi_host_parse(self, tmp_path):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        assert len(result.hosts) == 2
+        assert len(result.targets) == 2
+
+    def test_multi_host_canonical_targets(self, tmp_path):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        # web.corp.local has FQDN; 192.168.1.20 has no FQDN → uses IP
+        assert "web.corp.local" in result.targets
+        assert "192.168.1.20" in result.targets
+
+    def test_multi_host_finding_count(self, tmp_path):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        # 3 ReportItems across 2 hosts
+        assert len(result.findings) == 3
+
+    def test_critical_finding_parsed(self, tmp_path):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        critical = [f for f in result.findings if f.severity == 4]
+        assert len(critical) == 1
+        assert critical[0].plugin_name == "SSH Protocol Version 1 Enabled"
+
+    def test_no_findings_host(self, tmp_path):
+        path = _write_nessus(tmp_path, NO_FINDINGS_NESSUS)
+        result = parse_nessus_file(path)
+        assert len(result.hosts) == 1
+        assert len(result.findings) == 0
+        assert "10.0.0.99" in result.targets
+
+    def test_plugin_output_and_solution_captured(self, tmp_path):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        high = [f for f in result.findings if f.severity == 3][0]
+        assert "Serial: 1234" in high.plugin_output
+        assert "Renew the certificate" in high.solution
+
+
+# ---------------------------------------------------------------------------
+# DB seeding tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def fresh_db(tmp_path):
+    """Point tools at a fresh temp DB and clean up after."""
+    db_file = str(tmp_path / "recon.db")
+    original_db = tools.DB_PATH
+    original_out = tools.OUTPUT_DIR
+    tools.DB_PATH = db_file
+    tools.OUTPUT_DIR = str(tmp_path)
+    tools.init_db()
+    yield db_file
+    tools.DB_PATH = original_db
+    tools.OUTPUT_DIR = original_out
+
+
+class TestSeedDbFromNessus:
+    def test_open_ports_seeded(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        rows = conn.execute("SELECT target, port FROM open_ports").fetchall()
+        conn.close()
+        ports = {(r[0], r[1]) for r in rows}
+        # Both port 443 and port 80 should be recorded
+        assert ("target.example.com", "443") in ports
+        assert ("target.example.com", "80") in ports
+
+    def test_informational_findings_not_in_vulnerabilities(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        rows = conn.execute("SELECT template_id FROM vulnerabilities").fetchall()
+        conn.close()
+        template_ids = {r[0] for r in rows}
+        # Only severity>=1 items: pluginID 15901 (severity 3), not 11219 (severity 0)
+        assert "nessus-15901" in template_ids
+        assert "nessus-11219" not in template_ids
+
+    def test_vulnerability_severity_label(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        row = conn.execute(
+            "SELECT severity FROM vulnerabilities WHERE template_id = 'nessus-15901'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "high"
+
+    def test_vulnerability_description_prefixed(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        row = conn.execute(
+            "SELECT description FROM vulnerabilities WHERE template_id = 'nessus-15901'"
+        ).fetchone()
+        conn.close()
+        assert "[Nessus]" in row[0]
+        assert "SSL Certificate Expiry" in row[0]
+
+    def test_poc_contains_plugin_output(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        row = conn.execute(
+            "SELECT poc FROM vulnerabilities WHERE template_id = 'nessus-15901'"
+        ).fetchone()
+        conn.close()
+        assert "Serial: 1234" in row[0]
+
+    def test_subdomains_seeded_when_fqdn_differs_from_ip(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        rows = conn.execute("SELECT domain FROM subdomains").fetchall()
+        conn.close()
+        domains = {r[0] for r in rows}
+        assert "target.example.com" in domains
+
+    def test_no_duplicate_ports_on_reseed(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+        seed_db_from_nessus(result)  # seed twice
+
+        conn = sqlite3.connect(fresh_db)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM open_ports WHERE target='target.example.com' AND port='443'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1  # INSERT OR IGNORE prevents duplicates
+
+    def test_no_duplicate_vulns_on_reseed(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM vulnerabilities WHERE template_id='nessus-15901'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1
+
+    def test_tool_run_marked_for_each_target(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MINIMAL_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        row = conn.execute(
+            "SELECT 1 FROM tool_runs WHERE tool_name='nessus_import' "
+            "AND target='target.example.com'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+
+    def test_summary_counts_correct(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        summary = seed_db_from_nessus(result)
+
+        assert summary["hosts"] == 2
+        # 3 total findings, 3 are severity >= 1
+        assert summary["vulnerabilities"] == 3
+        # web.corp.local is a FQDN different from its IP → becomes subdomain
+        assert summary["subdomains"] == 1
+
+    def test_empty_scan_seeds_nothing(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, NO_FINDINGS_NESSUS)
+        result = parse_nessus_file(path)
+        summary = seed_db_from_nessus(result)
+
+        assert summary["vulnerabilities"] == 0
+        assert summary["open_ports"] == 0
+
+    def test_critical_severity_label_in_db(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        row = conn.execute(
+            "SELECT severity FROM vulnerabilities WHERE template_id='nessus-10881'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "critical"
+
+    def test_no_fqdn_uses_ip_as_vuln_target(self, tmp_path, fresh_db):
+        path = _write_nessus(tmp_path, MULTI_HOST_NESSUS)
+        result = parse_nessus_file(path)
+        seed_db_from_nessus(result)
+
+        conn = sqlite3.connect(fresh_db)
+        row = conn.execute(
+            "SELECT target FROM vulnerabilities WHERE template_id='nessus-70657'"
+        ).fetchone()
+        conn.close()
+        # 192.168.1.20 has no FQDN → IP used as canonical target
+        assert row[0] == "192.168.1.20"
+
+
+# ---------------------------------------------------------------------------
+# CLI argument tests (argparse smoke test — no actual swarm run)
+# ---------------------------------------------------------------------------
+
+class TestArgparse:
+    def test_nessus_flag_accepted(self, tmp_path):
+        """Ensure --nessus is a recognised argument without executing a swarm."""
+        import argparse
+        # Re-create the same parser as hacksmarter.py to test the arg shape
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-t", "--target", required=True)
+        parser.add_argument("-x", "--exclude")
+        parser.add_argument("-v", "--verbose", action="store_true")
+        parser.add_argument("-c", "--client")
+        parser.add_argument("-n", "--nessus", metavar="FILE")
+
+        fake_nessus = str(tmp_path / "scan.nessus")
+        args = parser.parse_args(["-t", "example.com", "-n", fake_nessus])
+        assert args.nessus == fake_nessus
+
+    def test_nessus_flag_optional(self):
+        import argparse
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-t", "--target", required=True)
+        parser.add_argument("-n", "--nessus", metavar="FILE")
+        args = parser.parse_args(["-t", "example.com"])
+        assert args.nessus is None


### PR DESCRIPTION
Hey, saw the feature request in the comments about accepting .nessus files 
and decided to take a stab at it.

The idea is simple - instead of the swarm starting blind, you can now feed it 
a Nessus export as a baseline so it picks up where your scanner left off and 
focuses on verifying and digging deeper into what Nessus already found rather 
than rediscovering everything from scratch.

Added a --nessus / -n flag to hacksmarter.py and a new nessus_parser.py module 
that handles the parsing and seeds the database before the swarm kicks off.

What it does:
- Parses Nessus XML v2 (.nessus) exports
- Seeds open ports, vulnerabilities and subdomains into the DB automatically
- Skips informational findings (severity 0) as vulns but still records the ports
- Prefers FQDN over IP as the target identifier
- Auto-adds any hosts from the .nessus file into scope
- Uses defusedxml so it handles untrusted scan files safely
- Tested this for at least 40 times with no errors! 

Usage:
  python hacksmarter.py -t example.com -n scan.nessus
  python hacksmarter.py -t example.com -n scan.nessus -c clientname -v

Hope it's useful, happy to adjust anything if it doesn't fit the project style.