### PR TITLE
feat: add Dehashed OSINT credential lookup tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 GOOGLE_API_KEY="your_api_key_here"
 WPSCAN_API_TOKEN="your_wpscan_token_here"
+
+# Dehashed OSINT credential lookup (https://dehashed.com)
+# Required for run_dehashed_tool — leaked credential recon
+DEHASHED_EMAIL="your_dehashed_account_email@example.com"
+DEHASHED_API_KEY="your_dehashed_api_key_here"

--- a/agents.py
+++ b/agents.py
@@ -33,6 +33,7 @@ from tools import (
     format_scope_tool,
     is_already_run,
     mark_as_run,
+    run_dehashed_tool,
     run_feroxbuster_tool,
     run_hydra_check,
     run_nc_banner_grab,
@@ -127,6 +128,7 @@ def get_db_data() -> dict:
         "open_ports": [],
         "vulnerabilities": [],
         "interesting_files": [],
+        "leaked_credentials": [],
         "tool_runs": {},
     }
 
@@ -159,6 +161,22 @@ def get_db_data() -> dict:
         c.execute("SELECT target, url, comment FROM interesting_files")
         db["interesting_files"] = [
             {"target": r[0], "url": r[1], "comment": r[2]} for r in c.fetchall()
+        ]
+
+        c.execute(
+            "SELECT domain, email, username, password, hashed_password, source "
+            "FROM leaked_credentials"
+        )
+        db["leaked_credentials"] = [
+            {
+                "domain": r[0],
+                "email": r[1],
+                "username": r[2],
+                "password": r[3],
+                "hashed_password": r[4],
+                "source": r[5],
+            }
+            for r in c.fetchall()
         ]
 
         c.execute("SELECT tool_name, target FROM tool_runs")
@@ -284,6 +302,7 @@ def recon_node(state: PentestState):
         run_wpscan_tool,
         run_feroxbuster_tool,
         run_httpx_tool,
+        run_dehashed_tool,
     ]
     recon_tools = _filter_tools(all_recon_tools, excluded)
 
@@ -297,14 +316,17 @@ def recon_node(state: PentestState):
 
     system_prompt = (
         f"You are a Tactical Recon Specialist. Current objective: {directives}\n"
-        "Find subdomains, scan ports, and check for WordPress vulnerabilities.\n\n"
+        "Find subdomains, scan ports, check for WordPress vulnerabilities, and query "
+        "Dehashed for leaked credentials associated with the target domain.\n\n"
         "### STRICT RULES ###\n"
         "1. ONLY scan the primary target and subdomains returned by subfinder.\n"
         "2. Use run_httpx_tool to verify a target is live BEFORE running feroxbuster "
         "or wpscan on it.\n"
         "3. If subfinder returns 0 subdomains, only the primary target is in scope.\n"
+        "4. Always run run_dehashed_tool on the primary target domain to check for "
+        "leaked credentials in breach databases.\n"
         f"{subdomain_ctx}\n"
-        "When finished, summarise all findings."
+        "When finished, summarise all findings including any leaked credentials."
     )
 
     agent = create_react_agent(llm, recon_tools, prompt=system_prompt)
@@ -318,6 +340,7 @@ def recon_node(state: PentestState):
         "subdomains": db["subdomains"],
         "open_ports": db["open_ports"],
         "interesting_files": db.get("interesting_files", []),
+        "leaked_credentials": db.get("leaked_credentials", []),
         "current_phase": "recon_conducted",
     }
 

--- a/hacksmarter.py
+++ b/hacksmarter.py
@@ -195,6 +195,7 @@ def run_swarm(
             "open_ports": [],
             "vulnerabilities": [],
             "interesting_files": [],
+            "leaked_credentials": [],
             "last_vuln_count": -1,
             "current_phase": "start",
             "strategy_directives": "",

--- a/state.py
+++ b/state.py
@@ -22,6 +22,7 @@ class PentestState(TypedDict):
     open_ports: Annotated[List[dict], _merge_unique]
     vulnerabilities: Annotated[List[dict], _merge_unique]
     interesting_files: Annotated[List[dict], _merge_unique]
+    leaked_credentials: Annotated[List[dict], _merge_unique]
     excluded_tools: List[str]
     verbose: bool
 

--- a/tests/test_dehashed_tool.py
+++ b/tests/test_dehashed_tool.py
@@ -1,0 +1,271 @@
+"""
+tests/test_dehashed_tool.py — Unit tests for run_dehashed_tool.
+
+Tests are fully offline — all HTTP calls are monkey-patched so no real
+Dehashed account is needed.
+"""
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Make sure the project root is on the path so we can import tools
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tools
+from tools import (
+    _assert_in_scope,
+    init_db,
+    is_already_run,
+    run_dehashed_tool,
+    set_allowed_scope,
+    set_output_dir,
+    update_db,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fake_response(payload: dict, status: int = 200):
+    """Return a mock object that mimics urllib.request.urlopen context manager."""
+    body = json.dumps(payload).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.status = status
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _make_http_error(code: int):
+    """Return a urllib.error.HTTPError with the given code."""
+    import urllib.error
+    return urllib.error.HTTPError(
+        url="https://api.dehashed.com/search",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=None,
+        fp=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test case
+# ---------------------------------------------------------------------------
+
+class TestRunDehashedTool(unittest.TestCase):
+
+    def setUp(self):
+        """Each test gets a fresh temp DB and a clean scope."""
+        self.tmpdir = tempfile.mkdtemp()
+        set_output_dir(self.tmpdir)
+        set_allowed_scope(["example.com"])
+
+    # ------------------------------------------------------------------ #
+    #  1. Missing credentials — should gracefully skip                    #
+    # ------------------------------------------------------------------ #
+    def test_missing_credentials_returns_skip(self):
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("DEHASHED_EMAIL", "DEHASHED_API_KEY")}
+        with patch.dict(os.environ, env, clear=True):
+            result = run_dehashed_tool.invoke({"domain": "example.com"})
+        self.assertIn("[SKIP]", result)
+        self.assertIn("DEHASHED_EMAIL", result)
+
+    # ------------------------------------------------------------------ #
+    #  2. Out-of-scope domain — should be blocked                         #
+    # ------------------------------------------------------------------ #
+    def test_out_of_scope_is_blocked(self):
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            result = run_dehashed_tool.invoke({"domain": "evil.com"})
+        self.assertIn("[SCOPE BLOCK]", result)
+
+    # ------------------------------------------------------------------ #
+    #  3. Already-run deduplication                                        #
+    # ------------------------------------------------------------------ #
+    def test_already_run_returns_skip(self):
+        tools.mark_as_run("dehashed", "example.com")
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            result = run_dehashed_tool.invoke({"domain": "example.com"})
+        self.assertIn("[SKIP]", result)
+        self.assertIn("already queried", result)
+
+    # ------------------------------------------------------------------ #
+    #  4. Successful response — credentials stored in DB                  #
+    # ------------------------------------------------------------------ #
+    def test_successful_response_stores_credentials(self):
+        payload = {
+            "total": 3,
+            "entries": [
+                {
+                    "email": "alice@example.com",
+                    "username": "alice",
+                    "password": "hunter2",
+                    "hashed_password": "",
+                    "database_name": "BreachDB-2022",
+                },
+                {
+                    "email": "bob@example.com",
+                    "username": "bob",
+                    "password": "",
+                    "hashed_password": "$2y$10$abcdefghijklmnopqrstuv",
+                    "database_name": "LeakedList-2023",
+                },
+                {
+                    "email": "charlie@example.com",
+                    "username": "charlie",
+                    "password": "s3cr3t!",
+                    "hashed_password": "",
+                    "database_name": "BreachDB-2022",
+                },
+            ],
+        }
+
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            with patch("urllib.request.urlopen", return_value=_make_fake_response(payload)):
+                result = run_dehashed_tool.invoke({"domain": "example.com"})
+
+        # Check return string
+        self.assertIn("example.com", result)
+        self.assertIn("3 total records", result)
+        self.assertIn("2 have plaintext", result)
+        self.assertIn("1 have hashed", result)
+
+        # Check DB persistence
+        conn = sqlite3.connect(tools.DB_PATH)
+        rows = conn.execute(
+            "SELECT email, username, password, hashed_password, source "
+            "FROM leaked_credentials WHERE domain='example.com'"
+        ).fetchall()
+        conn.close()
+
+        self.assertEqual(len(rows), 3)
+        emails = {r[0] for r in rows}
+        self.assertIn("alice@example.com", emails)
+        self.assertIn("bob@example.com", emails)
+        self.assertIn("charlie@example.com", emails)
+
+        # Passwords stored correctly
+        pw_map = {r[0]: r[2] for r in rows}
+        self.assertEqual(pw_map["alice@example.com"], "hunter2")
+        self.assertEqual(pw_map["bob@example.com"], "")  # only hash
+
+    # ------------------------------------------------------------------ #
+    #  5. Empty result set                                                 #
+    # ------------------------------------------------------------------ #
+    def test_empty_results_returns_informative_message(self):
+        payload = {"total": 0, "entries": []}
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            with patch("urllib.request.urlopen", return_value=_make_fake_response(payload)):
+                result = run_dehashed_tool.invoke({"domain": "example.com"})
+
+        self.assertIn("no leaked credentials", result.lower())
+
+        # Nothing written to DB
+        conn = sqlite3.connect(tools.DB_PATH)
+        count = conn.execute("SELECT COUNT(*) FROM leaked_credentials").fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 0)
+
+    # ------------------------------------------------------------------ #
+    #  6. 401 Unauthorized                                                 #
+    # ------------------------------------------------------------------ #
+    def test_401_returns_error_message(self):
+        env = {"DEHASHED_EMAIL": "bad@test.com", "DEHASHED_API_KEY": "wrong"}
+        with patch.dict(os.environ, env):
+            with patch("urllib.request.urlopen", side_effect=_make_http_error(401)):
+                result = run_dehashed_tool.invoke({"domain": "example.com"})
+        self.assertIn("[ERROR]", result)
+        self.assertIn("401", result)
+
+    # ------------------------------------------------------------------ #
+    #  7. 302 subscription redirect                                        #
+    # ------------------------------------------------------------------ #
+    def test_302_returns_subscription_message(self):
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            with patch("urllib.request.urlopen", side_effect=_make_http_error(302)):
+                result = run_dehashed_tool.invoke({"domain": "example.com"})
+        self.assertIn("[ERROR]", result)
+        self.assertIn("302", result)
+
+    # ------------------------------------------------------------------ #
+    #  8. Malformed JSON response                                          #
+    # ------------------------------------------------------------------ #
+    def test_malformed_json_returns_error(self):
+        bad_resp = MagicMock()
+        bad_resp.read.return_value = b"<html>not json</html>"
+        bad_resp.__enter__ = lambda s: s
+        bad_resp.__exit__ = MagicMock(return_value=False)
+
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            with patch("urllib.request.urlopen", return_value=bad_resp):
+                result = run_dehashed_tool.invoke({"domain": "example.com"})
+        self.assertIn("[ERROR]", result)
+        self.assertIn("non-JSON", result)
+
+    # ------------------------------------------------------------------ #
+    #  9. Protocol-prefixed domain is stripped correctly                  #
+    # ------------------------------------------------------------------ #
+    def test_protocol_prefix_stripped_in_query(self):
+        set_allowed_scope(["https://example.com"])
+        payload = {"total": 0, "entries": []}
+        captured_urls = []
+
+        def fake_urlopen(req, timeout=None):
+            captured_urls.append(req.full_url)
+            return _make_fake_response(payload)
+
+        env = {"DEHASHED_EMAIL": "user@test.com", "DEHASHED_API_KEY": "key123"}
+        with patch.dict(os.environ, env):
+            with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+                run_dehashed_tool.invoke({"domain": "https://example.com"})
+
+        self.assertTrue(captured_urls, "urlopen was never called")
+        # The query should use bare domain, not https://
+        self.assertIn("example.com", captured_urls[0])
+        self.assertNotIn("https%3A%2F%2F", captured_urls[0])
+
+    # ------------------------------------------------------------------ #
+    #  10. update_db deduplication — re-inserting same rows is idempotent #
+    # ------------------------------------------------------------------ #
+    def test_duplicate_credentials_are_deduplicated_in_db(self):
+        cred = {
+            "domain": "example.com",
+            "email": "dup@example.com",
+            "username": "dup",
+            "password": "pw",
+            "hashed_password": "",
+            "source": "TestDB",
+        }
+        update_db("leaked_credentials", [cred])
+        update_db("leaked_credentials", [cred])  # insert again
+
+        conn = sqlite3.connect(tools.DB_PATH)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM leaked_credentials WHERE email='dup@example.com'"
+        ).fetchone()[0]
+        conn.close()
+        self.assertEqual(count, 1, "Duplicate credential should be ignored")
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools.py
+++ b/tools.py
@@ -81,6 +81,8 @@ _SENSITIVE_ENV_KEYS = frozenset({
     "ANTHROPIC_API_KEY",
     "AWS_SECRET_ACCESS_KEY",
     "AWS_ACCESS_KEY_ID",
+    "DEHASHED_API_KEY",
+    "DEHASHED_EMAIL",
 })
 
 
@@ -113,6 +115,11 @@ def init_db():
     c.execute(
         "CREATE TABLE IF NOT EXISTS interesting_files "
         "(target TEXT, url TEXT, status INTEGER, comment TEXT, UNIQUE(target, url))"
+    )
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS leaked_credentials "
+        "(domain TEXT, email TEXT, username TEXT, password TEXT, hashed_password TEXT, "
+        "source TEXT, UNIQUE(domain, email, password))"
     )
     c.execute(
         "CREATE TABLE IF NOT EXISTS tool_runs "
@@ -158,6 +165,21 @@ def update_db(key: str, new_data: list):
                         v.get("severity"),
                         v.get("description"),
                         v.get("poc", ""),
+                    ),
+                )
+        elif key == "leaked_credentials":
+            for item in new_data:
+                c.execute(
+                    "INSERT OR IGNORE INTO leaked_credentials "
+                    "(domain, email, username, password, hashed_password, source) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (
+                        item.get("domain", ""),
+                        item.get("email", ""),
+                        item.get("username", ""),
+                        item.get("password", ""),
+                        item.get("hashed_password", ""),
+                        item.get("source", ""),
                     ),
                 )
         elif key == "interesting_files":
@@ -817,3 +839,116 @@ def run_feroxbuster_tool(
                 f"{len(all_findings)} interesting files found."
             )
         return f"Feroxbuster finished on {len(new_targets)} targets — 0 findings."
+
+
+@tool
+def run_dehashed_tool(domain: str) -> str:
+    """
+    Query the Dehashed API for leaked credentials associated with a domain.
+
+    Requires DEHASHED_EMAIL and DEHASHED_API_KEY environment variables.
+    Results (email, username, plaintext password, hashed password, source
+    database) are stored in the leaked_credentials table and returned as a
+    summary.  Only domain-scoped queries are made — no out-of-scope lookups.
+
+    Args:
+        domain: The target domain to search (e.g. 'example.com').
+    """
+    import urllib.request
+    import urllib.parse
+    import base64
+
+    try:
+        _assert_in_scope(domain)
+    except ValueError as exc:
+        return f"[SCOPE BLOCK] {exc}"
+
+    if is_already_run("dehashed", domain):
+        return f"[SKIP] Dehashed already queried for {domain}."
+
+    dehashed_email = os.environ.get("DEHASHED_EMAIL", "").strip()
+    dehashed_api_key = os.environ.get("DEHASHED_API_KEY", "").strip()
+
+    if not dehashed_email or not dehashed_api_key:
+        return (
+            "[SKIP] Dehashed credentials not configured. "
+            "Set DEHASHED_EMAIL and DEHASHED_API_KEY in your .env file."
+        )
+
+    logger.info("Querying Dehashed for domain: %s", domain)
+
+    # Bare domain without protocol for the query
+    bare_domain = re.sub(r"^https?://", "", domain).split("/")[0].split(":")[0]
+    query = urllib.parse.quote(bare_domain)
+    url = f"https://api.dehashed.com/search?query=domain%3A{query}&size=100"
+
+    credentials_b64 = base64.b64encode(
+        f"{dehashed_email}:{dehashed_api_key}".encode()
+    ).decode()
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Basic {credentials_b64}",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        mark_as_run("dehashed", domain)
+        if exc.code == 401:
+            return "[ERROR] Dehashed: invalid credentials (401). Check DEHASHED_EMAIL / DEHASHED_API_KEY."
+        if exc.code == 302:
+            return "[ERROR] Dehashed: subscription required or account issue (302)."
+        return f"[ERROR] Dehashed HTTP {exc.code}: {exc.reason}"
+    except urllib.error.URLError as exc:
+        return f"[ERROR] Dehashed network error: {exc.reason}"
+    except Exception as exc:
+        return f"[ERROR] Dehashed unexpected error: {exc}"
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        mark_as_run("dehashed", domain)
+        return f"[ERROR] Dehashed returned non-JSON response: {exc}"
+
+    entries = data.get("entries") or []
+    total = data.get("total", len(entries))
+
+    if not entries:
+        mark_as_run("dehashed", domain)
+        return f"Dehashed: no leaked credentials found for {bare_domain}."
+
+    credentials = []
+    for entry in entries:
+        credentials.append({
+            "domain": bare_domain,
+            "email": entry.get("email", ""),
+            "username": entry.get("username", ""),
+            "password": entry.get("password", ""),
+            "hashed_password": entry.get("hashed_password", ""),
+            "source": entry.get("database_name", ""),
+        })
+
+    update_db("leaked_credentials", credentials)
+    mark_as_run("dehashed", domain)
+
+    # Build a concise summary (avoid logging raw passwords at INFO level)
+    with_plaintext = sum(1 for c in credentials if c.get("password"))
+    with_hash = sum(1 for c in credentials if c.get("hashed_password"))
+
+    logger.info(
+        "Dehashed found %d entries for %s (%d plaintext, %d hashed).",
+        len(credentials), bare_domain, with_plaintext, with_hash,
+    )
+
+    return (
+        f"Dehashed results for {bare_domain}: {total} total records found "
+        f"(showing {len(credentials)}). "
+        f"{with_plaintext} have plaintext passwords, {with_hash} have hashed passwords. "
+        f"All stored in leaked_credentials table. "
+        f"Sample sources: {', '.join(set(c['source'] for c in credentials if c['source']))[:200]}"
+    )


### PR DESCRIPTION
Adds a Dehashed API integration to the recon pipeline. When DEHASHED_EMAIL and DEHASHED_API_KEY are set in .env, the agent automatically queries Dehashed for leaked credentials associated with the target domain and stores the results in the database alongside other findings.

What changed:

New run_dehashed_tool added to the recon agent
Results (email, username, plaintext/hashed passwords, source DB) stored in a new leaked_credentials table
Fully scope-enforced, only queries the authorised target domain.
Gracefully skips if credentials aren't configured, so no breaking change for existing users.

Setup:
Add to your .env:
DEHASHED_EMAIL=your@email.com
DEHASHED_API_KEY=your_api_key

Requires a Dehashed subscription at dehashed.com.